### PR TITLE
Fix 500 error upon GET request to /hello, closes #44

### DIFF
--- a/server/src/main/java/com/feeder/server/controllers/HelloController.java
+++ b/server/src/main/java/com/feeder/server/controllers/HelloController.java
@@ -3,6 +3,7 @@ package com.feeder.server.controllers;
 import com.feeder.server.ApplicationProperties;
 import com.feeder.server.models.Hello;
 import com.feeder.server.providers.reddit.RedditFeedProvider;
+import com.feeder.server.providers.reddit.RedditFeedProviderFactory;
 import net.dean.jraw.models.Listing;
 import net.dean.jraw.models.Submission;
 import org.slf4j.Logger;
@@ -19,12 +20,14 @@ import java.util.List;
 public class HelloController {
 
     private static final Logger logger = LoggerFactory.getLogger(HelloController.class);
-    @Autowired private ApplicationProperties properties;
-    @Autowired private RedditFeedProvider redditFeedProvider;
+    @Autowired private RedditFeedProviderFactory redditFeedProviderFactory;
+    @Autowired private ApplicationProperties applicationProperties;
+    private RedditFeedProvider redditFeedProvider;
 
     @GetMapping
     public Hello readHello() {
 
+        redditFeedProvider = redditFeedProviderFactory.createProvider(applicationProperties);
         List<Listing<Submission>> items = redditFeedProvider.getFeed(2);
         items.forEach(s -> logger.info(s.toString()));
         return new Hello("hello");

--- a/server/src/main/java/com/feeder/server/providers/reddit/RedditFeedProvider.java
+++ b/server/src/main/java/com/feeder/server/providers/reddit/RedditFeedProvider.java
@@ -1,43 +1,20 @@
 package com.feeder.server.providers.reddit;
-import com.feeder.server.ApplicationProperties;
 import net.dean.jraw.RedditClient;
-import net.dean.jraw.http.NetworkAdapter;
-import net.dean.jraw.http.OkHttpNetworkAdapter;
-import net.dean.jraw.http.UserAgent;
 import net.dean.jraw.models.Listing;
 import net.dean.jraw.models.Submission;
-import net.dean.jraw.oauth.Credentials;
-import net.dean.jraw.oauth.OAuthHelper;
 import net.dean.jraw.pagination.Paginator;
-import org.springframework.stereotype.Service;
+
 import java.util.List;
 
 /***
  * A RedditFeedProvider is responsible for retrieving Reddit posts from a users homepage from the Reddit API.
  */
-@Service
 public class RedditFeedProvider {
 
     private RedditClient redditClient;
 
-    /***
-     * Default constructor required for unit testing
-     */
-    public RedditFeedProvider() {}
-
-    public RedditFeedProvider(ApplicationProperties properties) {
-        validateRedditProperties(properties);
-
-        // UserAgent and Credentials are used to get an OAuth token for the RedditClient
-        UserAgent userAgent = new UserAgent("web", "com.feeder.server.providers.reddit",
-                "v0.1", properties.getRedditUsername());
-
-        Credentials credentials = Credentials.script(properties.getRedditUsername(), properties.getRedditPassword(),
-                properties.getRedditClientId(), properties.getRedditClientSecret());
-
-        NetworkAdapter adapter = new OkHttpNetworkAdapter(userAgent);
-
-        redditClient = getAuthenticatedClient(adapter, credentials);
+    public RedditFeedProvider(RedditClient redditClient) {
+        this.redditClient = redditClient;
     }
 
     /***
@@ -56,31 +33,5 @@ public class RedditFeedProvider {
 
         // TODO: Map the submissions to a different type for processing with other social media feeds
         return submissions;
-    }
-
-    protected RedditClient getAuthenticatedClient(NetworkAdapter adapter, Credentials credentials) {
-        return OAuthHelper.automatic(adapter, credentials);
-    }
-
-    private void validateRedditProperties(ApplicationProperties properties) {
-        if (properties == null) {
-            throw new IllegalStateException("ApplicationProperties is not defined");
-        }
-
-        if (properties.getRedditUsername() == null || properties.getRedditUsername().isBlank()) {
-            throw new IllegalStateException("providers.reddit.username is not defined");
-        }
-
-        if (properties.getRedditPassword() == null || properties.getRedditPassword().isBlank()) {
-            throw new IllegalStateException("providers.reddit.password is not defined");
-        }
-
-        if (properties.getRedditClientId() == null || properties.getRedditClientId().isBlank()) {
-            throw new IllegalStateException("providers.reddit.clientId is not defined");
-        }
-
-        if (properties.getRedditClientSecret() == null || properties.getRedditClientSecret().isBlank()) {
-            throw new IllegalStateException("providers.reddit.clientSecret is not defined");
-        }
     }
 }

--- a/server/src/main/java/com/feeder/server/providers/reddit/RedditFeedProviderFactory.java
+++ b/server/src/main/java/com/feeder/server/providers/reddit/RedditFeedProviderFactory.java
@@ -1,0 +1,68 @@
+package com.feeder.server.providers.reddit;
+
+import com.feeder.server.ApplicationProperties;
+import net.dean.jraw.RedditClient;
+import net.dean.jraw.http.NetworkAdapter;
+import net.dean.jraw.http.OkHttpNetworkAdapter;
+import net.dean.jraw.http.UserAgent;
+import net.dean.jraw.oauth.Credentials;
+import net.dean.jraw.oauth.OAuthHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedditFeedProviderFactory {
+
+    private RedditFeedProvider redditFeedProvider;
+
+    public RedditFeedProvider createProvider(ApplicationProperties properties) {
+        validateRedditProperties(properties);
+
+        // Do not create a new RedditFeedProvider if one already exists
+        // TODO: When implementing interactive OAuth we will need to create a Provider for each user
+        if (redditFeedProvider != null) {
+            return redditFeedProvider;
+        }
+
+        // UserAgent and Credentials are used to get an OAuth token for the RedditClient
+        UserAgent userAgent = new UserAgent("web", "com.feeder.server.providers.reddit",
+                "v0.1", properties.getRedditUsername());
+
+        Credentials credentials = Credentials.script(properties.getRedditUsername(), properties.getRedditPassword(),
+                properties.getRedditClientId(), properties.getRedditClientSecret());
+
+        NetworkAdapter adapter = new OkHttpNetworkAdapter(userAgent);
+
+        RedditClient redditClient = getAuthenticatedClient(adapter, credentials);
+
+        redditFeedProvider = new RedditFeedProvider(redditClient);
+
+        return redditFeedProvider;
+    }
+
+    protected RedditClient getAuthenticatedClient(NetworkAdapter adapter, Credentials credentials) {
+        return OAuthHelper.automatic(adapter, credentials);
+    }
+
+    private void validateRedditProperties(ApplicationProperties properties) {
+        if (properties == null) {
+            throw new IllegalStateException("ApplicationProperties is not defined");
+        }
+
+        if (properties.getRedditUsername() == null || properties.getRedditUsername().isBlank()) {
+            throw new IllegalStateException("providers.reddit.username is not defined");
+        }
+
+        if (properties.getRedditPassword() == null || properties.getRedditPassword().isBlank()) {
+            throw new IllegalStateException("providers.reddit.password is not defined");
+        }
+
+        if (properties.getRedditClientId() == null || properties.getRedditClientId().isBlank()) {
+            throw new IllegalStateException("providers.reddit.clientId is not defined");
+        }
+
+        if (properties.getRedditClientSecret() == null || properties.getRedditClientSecret().isBlank()) {
+            throw new IllegalStateException("providers.reddit.clientSecret is not defined");
+        }
+    }
+
+}

--- a/server/src/test/java/com/feeder/server/controllers/HelloControllerTests.java
+++ b/server/src/test/java/com/feeder/server/controllers/HelloControllerTests.java
@@ -1,7 +1,9 @@
 package com.feeder.server.controllers;
 
+import com.feeder.server.ApplicationProperties;
 import com.feeder.server.models.Hello;
 import com.feeder.server.providers.reddit.RedditFeedProvider;
+import com.feeder.server.providers.reddit.RedditFeedProviderFactory;
 import net.dean.jraw.models.Listing;
 import net.dean.jraw.models.Submission;
 import org.junit.jupiter.api.Test;
@@ -14,29 +16,26 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
 public class HelloControllerTests {
 
+    @Mock private RedditFeedProviderFactory redditFeedProviderFactory;
+    @Mock private RedditFeedProvider mockRedditFeedProvider;
+    @Mock private Listing<Submission> mockListing;
+
     @InjectMocks
     private HelloController subject;
-
-    @Mock
-    private RedditFeedProvider redditFeedProvider;
-    @Mock
-    private Listing<Submission> mockListing;
-
 
     @Test
     public void testHello() {
         // arrange
         when(mockListing.toString()).thenReturn("test");
         Listing[] listings = {mockListing};
-        when(redditFeedProvider.getFeed(anyInt())).thenReturn(Arrays.asList(listings));
+        when(mockRedditFeedProvider.getFeed(anyInt())).thenReturn(Arrays.asList(listings));
+        when(redditFeedProviderFactory.createProvider(any())).thenReturn(mockRedditFeedProvider);
 
         // act
         Hello response = subject.readHello();
@@ -44,5 +43,4 @@ public class HelloControllerTests {
         // assert
         assertEquals(response.getMessage(), "hello");
     }
-
 }

--- a/server/src/test/java/com/feeder/server/providers/reddit/RedditFeedProviderFactoryTest.java
+++ b/server/src/test/java/com/feeder/server/providers/reddit/RedditFeedProviderFactoryTest.java
@@ -1,0 +1,56 @@
+package com.feeder.server.providers.reddit;
+
+import com.feeder.server.ApplicationProperties;
+import net.dean.jraw.RedditClient;
+import net.dean.jraw.http.NetworkAdapter;
+import net.dean.jraw.oauth.Credentials;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RedditFeedProviderFactoryTest {
+    @Mock
+    private RedditClient mockRedditClient;
+    @Mock
+    private ApplicationProperties applicationProperties;
+    private TestableRedditFeedProviderFactory subject;
+
+
+    @BeforeEach
+    void setUp() {
+        subject = new TestableRedditFeedProviderFactory();
+    }
+
+    @Test
+    void testCreateProvider() {
+        // act
+        RedditFeedProvider redditFeedProvider = subject.createProvider(new ApplicationProperties("test","test","test","test"));
+
+        // assert
+        assertNotNull(redditFeedProvider);
+    }
+
+    @Test
+    public void testPropertyValidation() {
+        try {
+            subject.createProvider(new ApplicationProperties("","","",""));
+            fail();
+        } catch (IllegalStateException e) {
+
+        }
+    }
+
+    public class TestableRedditFeedProviderFactory extends RedditFeedProviderFactory {
+
+        public TestableRedditFeedProviderFactory() {
+            super();
+        }
+
+        @Override
+        protected RedditClient getAuthenticatedClient(NetworkAdapter adapter, Credentials credentials) {
+            return mockRedditClient;
+        }
+    }
+}

--- a/server/src/test/java/com/feeder/server/providers/reddit/RedditFeedProviderTest.java
+++ b/server/src/test/java/com/feeder/server/providers/reddit/RedditFeedProviderTest.java
@@ -1,31 +1,29 @@
 package com.feeder.server.providers.reddit;
-import com.feeder.server.ApplicationProperties;
+
 import net.dean.jraw.RedditClient;
-import net.dean.jraw.http.NetworkAdapter;
 import net.dean.jraw.models.Listing;
 import net.dean.jraw.models.Submission;
 import net.dean.jraw.models.SubredditSort;
-import net.dean.jraw.oauth.Credentials;
 import net.dean.jraw.pagination.DefaultPaginator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class RedditFeedProviderTest {
 
     @Mock private RedditClient mockRedditClient;
-    private TestableRedditFeedProvider subject;
-    private ApplicationProperties mockProperties = new ApplicationProperties("test","test","test","test");
+    @InjectMocks private RedditFeedProvider subject;
 
     @Test
     public void testGetFeed() {
@@ -40,33 +38,10 @@ public class RedditFeedProviderTest {
         when(builder.build()).thenReturn(mockPaginator);
         when(mockPaginator.accumulate(anyInt())).thenReturn(mockList);
 
-        subject = new TestableRedditFeedProvider(mockProperties);
-
         // act
         List<Listing<Submission>> result = subject.getFeed(expectedNumberOfListings);
 
         // assert
         assertEquals(result.size(), expectedNumberOfListings);
-    }
-
-    @Test
-    public void testPropertyValidation() {
-        try {
-            subject = new TestableRedditFeedProvider(new ApplicationProperties("","","",""));
-            fail();
-        } catch (IllegalStateException e) {
-
-        }
-    }
-
-    private class TestableRedditFeedProvider extends RedditFeedProvider {
-        public TestableRedditFeedProvider(ApplicationProperties mockProperties) {
-            super(mockProperties);
-        }
-
-        @Override
-        protected RedditClient getAuthenticatedClient(NetworkAdapter adapter, Credentials credentials) {
-            return mockRedditClient;
-        }
     }
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #44

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
## What is the current behavior?
- 500 error upon hitting the `/hello` endpoint

## What is the new behavior?
- `/hello` endpoint returns `200 OK` response with Reddit API data collected

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current upstream repo
- [x] Added new tests to the test suite for the feature
- [x] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [x] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->


## Other information
- This was caused by RedditFeedProvider being instantiated via spring IoC
using the parameterless constructor. This constructor was only meant to be
used for unit tests. To fix this a Factory was made to better control the
complex creation of the RedditFeedProvider.

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
