### PR TITLE
Changed "Spotify" to "Hacker News" in README, closes #109

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We are using the React framework to manage the front-end UI and using a Java ser
 #### Supported services
 - GitHub
 - Reddit
-- Spotify
+- Hacker News
 - Twitter
 
 *Created for Assignment 1 of the SOFTENG701 course at the University of Auckland*


### PR DESCRIPTION
GitHub Issue (If applicable): #109 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Documentation content changes


## What is the current behavior?

Main README includes Spotify as a supported service.

## What is the new behavior?

Main README now has "Hacker News" in place of "Spotify"

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [x] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


<!-- If this PR contains a breaking change, please describe the impact below, and why this change had to be introduced.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
<!-- Template modified from Platform Uno Github, under the Apache 2.0 License-->
