### PR TITLE
Integrated COVID19 data

### DIFF
--- a/client/src/common/mapping.js
+++ b/client/src/common/mapping.js
@@ -14,7 +14,7 @@ export const mapFeedItem = item => {
     case 'WEATHER':
       return {};
     case 'COVIDNINETEEN':
-      return {};
+      return mapCovidNineteenItem(item);
     default:
       throw new Error(`feedType ${item.feedType} unsupported`);
   }
@@ -59,4 +59,18 @@ const mapHackerNewsItem = item => ({
   mainText: item.text,
   relativeTime: moment(item.time * 1000).fromNow(),
   mediaSourceLink: item.url,
+});
+
+const mapCovidNineteenItem = item => ({
+  media: 'covidNineteen',
+  totalConfirmed: item.totalConfirmed,
+  totalDeaths: item.totalDeaths,
+  totalProbable: item.totalProbable,
+  totalRecovered: item.totalRecovered,
+  totalHospitalised: item.totalHospitalised,
+  newConfirmed: item.newConfirmed,
+  newDeaths: item.newDeaths,
+  newProbable: item.newProbable,
+  newRecovered: item.newRecovered,
+  newHospitalised: item.newHospitalised,
 });

--- a/client/src/components/FilterBar.jsx
+++ b/client/src/components/FilterBar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Chip from '@material-ui/core/Chip';
 import DoneIcon from '@material-ui/icons/Done';
 import ClearIcon from '@material-ui/icons/Clear';
+import ErrorTwoToneIcon from '@material-ui/icons/ErrorTwoTone';
 import { Icon } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { loadCSS } from 'fg-loadcss';
@@ -44,6 +45,12 @@ const FilterBar = ({ setFilters }) => {
       key: 'twitter',
       label: 'Twitter',
       icon: <Icon className="fab fa-twitter" />,
+      on: true,
+    },
+    {
+      key: 'covidNineteen',
+      label: 'Covid19',
+      icon: <ErrorTwoToneIcon />,
       on: true,
     },
   ]);

--- a/client/src/components/MediaCard.jsx
+++ b/client/src/components/MediaCard.jsx
@@ -28,6 +28,7 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'column',
     justifyContent: 'space-between',
   },
+
   media: {
     height: 0,
     paddingTop: '56.25%', // 16:9
@@ -82,6 +83,8 @@ export const MediaCard = props => {
         return '#010101';
       case 'twitter':
         return '#05ACF0';
+      case 'covidNineteen':
+        return '#B22222';
       default:
         return '#b3b3b3';
     }
@@ -102,6 +105,71 @@ export const MediaCard = props => {
     }
   };
 
+  if (props.media === 'covidNineteen') {
+    return (
+      <div position="fixed" top={0} left={0}>
+        <Card
+          className={classNames(
+            classes.root,
+            props.getTheme === 'light' ? classes.lightTheme : classes.darkTheme
+          )}
+        >
+          <CardHeader
+            avatar={
+              <Avatar
+                src={
+                  'https://img.icons8.com/emoji/48/000000/exclamation-mark-emoji.png'
+                }
+                className={classes.avatar}
+              />
+            }
+            title={'COVID19 UPDATE'}
+          />
+
+          <CardContent>
+            <Typography variant="body2" component="p">
+              {'New Confirmed Cases: ' + props.newConfirmed}
+            </Typography>
+            <Typography variant="body2" component="p">
+              {'New Probable Cases: ' + props.newProbable}
+            </Typography>
+            <Typography variant="body2" component="p">
+              {'New Hospitalised: ' + props.newHospitalised}
+            </Typography>
+            <Typography variant="body2" component="p">
+              {'New Recovered: ' + props.newRecovered}
+            </Typography>
+            <Typography variant="body2" component="p">
+              {'New Deaths: ' + props.newDeaths}
+            </Typography>
+            <Typography variant="body2" component="p">
+              {'------------    '}
+            </Typography>
+            <Typography variant="body2" component="p">
+              {'Total Confirmed Cases: ' + props.totalConfirmed}
+            </Typography>
+            <Typography variant="body2" component="p">
+              {'Total Probable Cases: ' + props.totalProbable}
+            </Typography>
+            <Typography variant="body2" component="p">
+              {'Total Hospitalised: ' + props.totalHospitalised}
+            </Typography>
+            <Typography variant="body2" component="p">
+              {'Total Recovered: ' + props.totalRecovered}
+            </Typography>
+            <Typography variant="body2" component="p">
+              {'Total Deaths: ' + props.totalDeaths}
+            </Typography>
+          </CardContent>
+
+          <CardActions
+            style={{ backgroundColor: barColour(props.media) }}
+            disableSpacing
+          ></CardActions>
+        </Card>
+      </div>
+    );
+  }
   return (
     <div>
       <Card

--- a/client/src/pages/FeedPage.jsx
+++ b/client/src/pages/FeedPage.jsx
@@ -190,10 +190,11 @@ export const FeedPage = () => {
       >
         {mappedFeed.map(
           (item, i) =>
-            filters.includes(item.media) &&
-            isSearchedPost(search, item) && (
+            ((filters.includes(item.media) && isSearchedPost(search, item)) ||
+              item.media === 'covidNineteen') && (
               <MediaCard {...item} getTheme={theme} />
             )
+        )}
         )}
       </StackGrid>
       <Waypoint onEnter={onEnter} />

--- a/client/src/pages/FeedPage.jsx
+++ b/client/src/pages/FeedPage.jsx
@@ -59,6 +59,7 @@ export const FeedPage = () => {
     'hackernews',
     'github',
     'twitter',
+    'covidNineteen',
   ]);
   const [filterInit, setFilterInit] = React.useState(false);
   const [search, setSearch] = React.useState([]);
@@ -190,8 +191,10 @@ export const FeedPage = () => {
       >
         {mappedFeed.map(
           (item, i) =>
-            ((filters.includes(item.media) && isSearchedPost(search, item)) ||
-              item.media === 'covidNineteen') && (
+            ((item.media === 'covidNineteen' &&
+              filters.includes('covidNineteen')) ||
+              (filters.includes(item.media) &&
+                isSearchedPost(search, item))) && (
               <MediaCard {...item} getTheme={theme} />
             )
         )}


### PR DESCRIPTION
Integrated the covid19 data into the front end. Data appears in a media card within the feed. Could potentially add functionality to make it stay in a fixed position on the screen


GitHub Issue (If applicable): #172 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature 
- Integration

## What is the current behavior?

Currently the COVID19 is not integrated with the frontend


## What is the new behavior?

Have integrated the COVID19 data with the frontend so that it is displayed in a media card in the main feed. Decided against doing a sidebar for the data display as it detracted from the current UI (media card looked cleaner).


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current upstream repo
- [ ] Added new tests to the test suite for the feature
- [ ] Tested the full test suite, and ensured that the feature does not break current build.
- [ ] Docs have been added/updated which fit (for bug fixes / features)
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)
- [ ] Checked licensing of Frameworks/Libraries (if applicable) 


## Other information

Could extend the functionality so the COVID card has a fixed position at the top of the screen 


